### PR TITLE
Send CPU stats per core 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var session=require("stats-influxdb").newSession({
     }
 });
 
-session.cpu();  //collect current cpu usage (during next 100ms) and send to influxdb as 'cpu,unit=unit1,project=myProject core1=40,core2=24,core3=1,core4=80'
+session.cpu();  //collect current cpu usage (during next 500ms) and send to influxdb as 'cpu,unit=unit1,project=myProject,name=core1,core=40'. Each core is sent separately so data can be aggregated easily.
 session.mem();  //collect current mem usage 'mem,unit=unit1,project=myProject used=2000,used_ratio=70'
 session.disk("/"); //collect current disk usage 'disk,unit=unit1,project=myProject used=123456,used_ration=20'
 session.pidusage(); //collect current pid usage 'process,pid=<pid> mem=<mem in byte>,cpu=<cpu percent>'

--- a/lib/api/cpu.js
+++ b/lib/api/cpu.js
@@ -6,19 +6,18 @@ module.exports = function (session) {
     var prevTotal = getTotal();
     setTimeout(function () {
       var curTotal = getTotal();
-      var values = [];
       for (var core in curTotal) {
         var prev = prevTotal[core];
         var cur = curTotal[core];
         var deltaTotal = cur.total - prev.total;
         var deltaUsed = cur.used - prev.used;
-        values.push(core + "=" + Math.round(deltaUsed / deltaTotal * 100));
+        send(session, "cpu", "name="+core+",core=" + Math.round(deltaUsed / deltaTotal * 100));
       }
-      send(session, "cpu", values.join(","));
+
       if (cb) {
         cb();
       }
-    }, 100);
+    }, 500);
   };
 };
 

--- a/lib/api/cpu.js
+++ b/lib/api/cpu.js
@@ -11,7 +11,7 @@ module.exports = function (session) {
         var cur = curTotal[core];
         var deltaTotal = cur.total - prev.total;
         var deltaUsed = cur.used - prev.used;
-        send(session, "cpu", "name="+core+",core=" + Math.round(deltaUsed / deltaTotal * 100));
+        send(session, "cpu,name="+core, "value=" + Math.round(deltaUsed / deltaTotal * 100));
       }
 
       if (cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-influxdb",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "statistics lib using influxdbudp module",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-influxdb",
-  "version": "3.0.0",
+  "version": "2.2.0-alpha",
   "description": "statistics lib using influxdbudp module",
   "main": "index.js",
   "scripts": {

--- a/test/cpu.js
+++ b/test/cpu.js
@@ -32,7 +32,7 @@ describe("cpu probe", function() {
     var cpu = proxyquire("../lib/api/cpu", proxy)(session);
     cpu(function() {
       sinon.assert.calledOnce(proxy["../send"]);
-      sinon.assert.calledWith(proxy["../send"], session, "cpu","core1=50");
+      sinon.assert.calledWith(proxy["../send"], session, "cpu","name=core1,core=50");
       done();
     });
   });


### PR DESCRIPTION
Changes to send CPU stats per core. This allows for better and easier graphing of the CPU data.
CPU stats will now be sent as:
`cpu,unit=unit1,project=myProject,name=core1,core=40`
